### PR TITLE
issue-239: added support for harvesting over https

### DIFF
--- a/openwis-metadataportal/oaipmh/src/test/java/org/fao/oaipmh/requests/TransportTest.java
+++ b/openwis-metadataportal/oaipmh/src/test/java/org/fao/oaipmh/requests/TransportTest.java
@@ -1,0 +1,51 @@
+package org.fao.oaipmh.requests;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class TransportTest {
+
+   @Test
+   public void testSetUrl() throws MalformedURLException {
+      Transport t1 = new Transport();
+      Transport t2 = new Transport();
+      Transport t3 = new Transport();
+      Transport t4 = new Transport();
+      
+      t1.setUrl(new URL("http://www.example.com/oaipmh/endpoint"));
+      t2.setUrl(new URL("http://localhost:8080/my-oaipmh-endpoint#with-a-fragment"));
+      t3.setUrl(new URL("https://secure.example.com/encrypted/endpoint"));
+      t4.setUrl(new URL("https://10.64.33.123:9999/encrypted/endpoint/on/another/port"));
+      
+      Assert.assertEquals("www.example.com", t1.getHost());
+      Assert.assertEquals("localhost", t2.getHost());
+      Assert.assertEquals("secure.example.com", t3.getHost());
+      Assert.assertEquals("10.64.33.123", t4.getHost());
+
+      Assert.assertEquals(80, t1.getPort());
+      Assert.assertEquals(8080, t2.getPort());
+      Assert.assertEquals(443, t3.getPort());
+      Assert.assertEquals(9999, t4.getPort());
+
+      Assert.assertEquals("/oaipmh/endpoint", t1.getAddress());
+      Assert.assertEquals("/my-oaipmh-endpoint", t2.getAddress());
+      Assert.assertEquals("/encrypted/endpoint", t3.getAddress());
+      Assert.assertEquals("/encrypted/endpoint/on/another/port", t4.getAddress());
+      
+      Assert.assertEquals(Transport.Scheme.HTTP, t1.getScheme());
+      Assert.assertEquals(Transport.Scheme.HTTP, t2.getScheme());
+      Assert.assertEquals(Transport.Scheme.HTTPS, t3.getScheme());
+      Assert.assertEquals(Transport.Scheme.HTTPS, t4.getScheme());
+   }
+   
+   @Test(expected=MalformedURLException.class)
+   public void testSetUrlWithBadScheme() throws MalformedURLException {
+      Transport t1 = new Transport();
+      
+      t1.setUrl(new URL("file://bladibla/this/scheme/is/not/supported"));
+   }
+}

--- a/resources/vagrant/provisioning/provision-portals.sh
+++ b/resources/vagrant/provisioning/provision-portals.sh
@@ -43,7 +43,8 @@ sudo -iu openwis mkdir "$openwisHome/staging"
 # yum install -y java-1.7.0-openjdk-devel.x86_64
 
 # Install latest compatible JDK (still available in YUM).
-yum install -y java-1.7.0-openjdk-devel-1.7.0.101-2.6.6.4.el6_8
+#yum install -y java-1.7.0-openjdk-devel-1.7.0.101-2.6.6.4.el6_8
+yum install -y java-1.7.0-openjdk-devel-1.7.0.121
 
 #echo "Unpacking Java"
 #sudo -iu openwis tar -xvz -C "$openwisOpt" -f /vagrant/dependencies/jdk-7u51-linux-x64.tar.gz


### PR DESCRIPTION
Added support for harvesting metadata from a HTTPS OAI-PMH endpoint.
This picks up the correct scheme from the URL.  It also now uses the
default port number of the scheme instead of defaulting to port 80.

This PR contains the fixes for #239.